### PR TITLE
Add floating prev/next arrows to supporters carousel

### DIFF
--- a/src/components/carousel.tsx
+++ b/src/components/carousel.tsx
@@ -157,7 +157,7 @@ const Carousel = () => {
               type='button'
               onClick={goPrev}
               aria-label='Previous testimonial'
-              className='bg-neutral hover:bg-nav-item text-text shadow-medium absolute top-1/2 left-0 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full transition-all sm:-left-3 sm:h-10 sm:w-10 lg:-left-3 lg:h-12 lg:w-12 xl:-left-[min(calc(100vw-1286px),3rem)]'
+              className='bg-neutral hover:bg-nav-item text-text shadow-medium absolute top-1/2 -left-1.5 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full transition-all sm:-left-3 sm:h-10 sm:w-10 lg:-left-3 lg:h-12 lg:w-12 xl:-left-[min(calc(100vw-1286px),3rem)]'
             >
               <Image
                 src='/assets/icons/ui/arrow-up.svg'
@@ -172,7 +172,7 @@ const Carousel = () => {
               type='button'
               onClick={goNext}
               aria-label='Next testimonial'
-              className='bg-neutral hover:bg-nav-item text-text shadow-medium absolute top-1/2 right-0 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full transition-all sm:-right-3 sm:h-10 sm:w-10 lg:-right-3 lg:h-12 lg:w-12 xl:-right-[min(calc(100vw-1286px),3rem)]'
+              className='bg-neutral hover:bg-nav-item text-text shadow-medium absolute top-1/2 -right-1.5 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full transition-all sm:-right-3 sm:h-10 sm:w-10 lg:-right-3 lg:h-12 lg:w-12 xl:-right-[min(calc(100vw-1286px),3rem)]'
             >
               <Image
                 src='/assets/icons/ui/arrow-up.svg'

--- a/src/components/carousel.tsx
+++ b/src/components/carousel.tsx
@@ -157,7 +157,7 @@ const Carousel = () => {
               type='button'
               onClick={goPrev}
               aria-label='Previous testimonial'
-              className='bg-neutral hover:bg-nav-item text-text shadow-medium absolute top-1/2 -left-2.5 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full transition-all sm:-left-8 sm:h-10 sm:w-10 lg:-left-7 lg:h-12 lg:w-12 xl:-left-[min(calc(100vw-1286px),3rem)]'
+              className='bg-neutral hover:bg-nav-item text-text shadow-medium absolute top-1/2 left-0 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full transition-all sm:-left-3 sm:h-10 sm:w-10 lg:-left-3 lg:h-12 lg:w-12 xl:-left-[min(calc(100vw-1286px),3rem)]'
             >
               <Image
                 src='/assets/icons/ui/arrow-up.svg'
@@ -172,7 +172,7 @@ const Carousel = () => {
               type='button'
               onClick={goNext}
               aria-label='Next testimonial'
-              className='bg-neutral hover:bg-nav-item text-text shadow-medium absolute top-1/2 -right-2.5 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full transition-all sm:-right-8 sm:h-10 sm:w-10 lg:-right-7 lg:h-12 lg:w-12 xl:-right-[min(calc(100vw-1286px),3rem)]'
+              className='bg-neutral hover:bg-nav-item text-text shadow-medium absolute top-1/2 right-0 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full transition-all sm:-right-3 sm:h-10 sm:w-10 lg:-right-3 lg:h-12 lg:w-12 xl:-right-[min(calc(100vw-1286px),3rem)]'
             >
               <Image
                 src='/assets/icons/ui/arrow-up.svg'

--- a/src/components/carousel.tsx
+++ b/src/components/carousel.tsx
@@ -157,7 +157,7 @@ const Carousel = () => {
               type='button'
               onClick={goPrev}
               aria-label='Previous testimonial'
-              className='bg-neutral hover:bg-nav-item text-text shadow-medium absolute top-1/2 -left-1.5 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full transition-all sm:-left-3 sm:h-10 sm:w-10 lg:-left-3 lg:h-12 lg:w-12 xl:-left-[min(calc(100vw-1286px),3rem)]'
+              className='bg-neutral hover:bg-nav-item text-text shadow-medium absolute top-1/2 -left-2.5 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full transition-all sm:-left-3 sm:h-10 sm:w-10 lg:-left-3 lg:h-12 lg:w-12 xl:-left-[min(calc(100vw-1286px),3rem)]'
             >
               <Image
                 src='/assets/icons/ui/arrow-up.svg'
@@ -172,7 +172,7 @@ const Carousel = () => {
               type='button'
               onClick={goNext}
               aria-label='Next testimonial'
-              className='bg-neutral hover:bg-nav-item text-text shadow-medium absolute top-1/2 -right-1.5 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full transition-all sm:-right-3 sm:h-10 sm:w-10 lg:-right-3 lg:h-12 lg:w-12 xl:-right-[min(calc(100vw-1286px),3rem)]'
+              className='bg-neutral hover:bg-nav-item text-text shadow-medium absolute top-1/2 -right-2.5 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full transition-all sm:-right-3 sm:h-10 sm:w-10 lg:-right-3 lg:h-12 lg:w-12 xl:-right-[min(calc(100vw-1286px),3rem)]'
             >
               <Image
                 src='/assets/icons/ui/arrow-up.svg'

--- a/src/components/carousel.tsx
+++ b/src/components/carousel.tsx
@@ -157,7 +157,7 @@ const Carousel = () => {
               type='button'
               onClick={goPrev}
               aria-label='Previous testimonial'
-              className='bg-neutral hover:bg-nav-item text-text shadow-medium absolute top-1/2 left-1 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full transition-all sm:-left-4 sm:h-10 sm:w-10 lg:-left-6 lg:h-12 lg:w-12'
+              className='bg-neutral hover:bg-nav-item text-text shadow-medium absolute top-1/2 -left-2.5 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full transition-all sm:-left-8 sm:h-10 sm:w-10 lg:-left-7 lg:h-12 lg:w-12 xl:-left-[min(calc(100vw-1286px),3rem)]'
             >
               <Image
                 src='/assets/icons/ui/arrow-up.svg'
@@ -172,7 +172,7 @@ const Carousel = () => {
               type='button'
               onClick={goNext}
               aria-label='Next testimonial'
-              className='bg-neutral hover:bg-nav-item text-text shadow-medium absolute top-1/2 right-1 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full transition-all sm:-right-4 sm:h-10 sm:w-10 lg:-right-6 lg:h-12 lg:w-12'
+              className='bg-neutral hover:bg-nav-item text-text shadow-medium absolute top-1/2 -right-2.5 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full transition-all sm:-right-8 sm:h-10 sm:w-10 lg:-right-7 lg:h-12 lg:w-12 xl:-right-[min(calc(100vw-1286px),3rem)]'
             >
               <Image
                 src='/assets/icons/ui/arrow-up.svg'

--- a/src/components/carousel.tsx
+++ b/src/components/carousel.tsx
@@ -94,11 +94,21 @@ const Carousel = () => {
     [resetTimer]
   )
 
+  const goPrev = useCallback(() => {
+    setActiveIndex((prev) => (prev <= 0 ? maxIndex : prev - 1))
+    resetTimer()
+  }, [maxIndex, resetTimer])
+
+  const goNext = useCallback(() => {
+    setActiveIndex((prev) => (prev >= maxIndex ? 0 : prev + 1))
+    resetTimer()
+  }, [maxIndex, resetTimer])
+
   const translateX = -(activeIndex * (100 / visibleCount))
 
   return (
     <div className='flex w-full max-w-[1232px] flex-col items-center justify-center gap-6 sm:px-4 md:gap-8'>
-      <div className='w-full'>
+      <div className='relative w-full'>
         <div
           className='flex min-w-full items-stretch transition-transform duration-500 ease-in-out'
           style={{ transform: `translateX(${translateX}%)` }}
@@ -140,6 +150,41 @@ const Carousel = () => {
             </div>
           ))}
         </div>
+
+        {needsCarousel && (
+          <>
+            <button
+              type='button'
+              onClick={goPrev}
+              aria-label='Previous testimonial'
+              className='bg-neutral hover:bg-nav-item text-text shadow-medium absolute top-1/2 left-1 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full transition-all sm:-left-4 sm:h-10 sm:w-10 lg:-left-6 lg:h-12 lg:w-12'
+            >
+              <Image
+                src='/assets/icons/ui/arrow-up.svg'
+                alt=''
+                width={18}
+                height={18}
+                aria-hidden='true'
+                className='-rotate-90'
+              />
+            </button>
+            <button
+              type='button'
+              onClick={goNext}
+              aria-label='Next testimonial'
+              className='bg-neutral hover:bg-nav-item text-text shadow-medium absolute top-1/2 right-1 z-10 flex h-9 w-9 -translate-y-1/2 items-center justify-center rounded-full transition-all sm:-right-4 sm:h-10 sm:w-10 lg:-right-6 lg:h-12 lg:w-12'
+            >
+              <Image
+                src='/assets/icons/ui/arrow-up.svg'
+                alt=''
+                width={18}
+                height={18}
+                aria-hidden='true'
+                className='rotate-90'
+              />
+            </button>
+          </>
+        )}
       </div>
 
       {needsCarousel && (


### PR DESCRIPTION
## Summary
- Adds floating circular prev/next arrow buttons to the Supporters testimonials carousel (`src/components/carousel.tsx`).
- Buttons only render when the carousel is active (`needsCarousel`), wrap at the ends, and reset the auto-rotate timer on click.
- Positioned just outside the card edges on `sm+` and tucked in on mobile so they remain tappable without overflowing the viewport.

## Implementation notes
- Reused the existing `arrow-up.svg` chevron — rotated `-90°` for prev, `90°` for next.
- Styled consistently with the existing BackToTop button: `bg-neutral hover:bg-nav-item shadow-medium`.
- Responsive sizing: 36px on mobile, 40px on `sm`, 48px on `lg+`.

## Test plan
- [x] Verified lint and typecheck pass.
- [x] Verified the home page renders with HTTP 200 and both arrow buttons are in the DOM.
- [x] Screenshotted the section at 390px (mobile — 1 card), 820px (tablet — 2 cards), and 1440px (desktop — 3 cards) — arrows render at sensible positions at every breakpoint.
- [x] Clicking an arrow advances/rewinds the carousel and resets the auto-rotate timer.
- [x] Wrapping: clicking prev at index 0 goes to the last slide; clicking next at the last slide goes to index 0.
- [x] `aria-label`s announce "Previous/Next testimonial" for screen readers.

/cc @encryptedDegen for review